### PR TITLE
fix: ensure string conversion for responses and reference answers 

### DIFF
--- a/src/encourage/metrics/classic.py
+++ b/src/encourage/metrics/classic.py
@@ -361,7 +361,7 @@ class DropF1(Metric):
 
         scores: list[float] = []
         for r in responses:
-            prediction: str = r.response
+            prediction: str = str(r.response)
             references: Union[str, list[str]] = str(r.meta_data["reference_answer"]) or []
             if isinstance(references, str):
                 references = [references]


### PR DESCRIPTION
Correction of the error so that responses that are int are not processed correctly.